### PR TITLE
Missing spans

### DIFF
--- a/frontend/freebase2wikidata.js
+++ b/frontend/freebase2wikidata.js
@@ -98,6 +98,7 @@ $(document).ready(function() {
                   '</span>' +
                   ']' +
                 '</span>' +
+                '<span class="wikibase-toolbar wikibase-toolbar-item wikibase-toolbar-container">' +
                   '[' +
                   '<span class="wikibase-toolbarbutton wikibase-toolbar-item wikibase-toolbar-button wikibase-toolbar-button-edit">' +
                     '<a class="f2w-button f2w-source f2w-edit" href="#" data-statement-id="{{statement-id}}" data-property="{{data-property}}" data-object="{{data-object}}" data-source-property="{{data-source-property}}" data-source-object="{{data-source-object}}">edit</a>' +

--- a/frontend/freebase2wikidata.js
+++ b/frontend/freebase2wikidata.js
@@ -177,6 +177,8 @@ $(document).ready(function() {
                   '<a class="f2w-button f2w-property f2w-approve" href="#" data-statement-id="{{statement-id}}" data-property="{{data-property}}" data-object="{{data-object}}">approve</a>' +
                 '</span>' +
                 ']' +
+              '</span>' +
+              '<span class="wikibase-toolbar-item wikibase-toolbar wikibase-toolbar-container">' +
                 '[' +
                 '<span class="wikibase-toolbarbutton wikibase-toolbar-item wikibase-toolbar-button wikibase-toolbar-button-edit">' +
                   '<a class="f2w-button f2w-property f2w-reject" href="#" data-statement-id="{{statement-id}}" data-property="{{data-property}}" data-object="{{data-object}}">reject</a>' +


### PR DESCRIPTION
The screenshot in #9 shows what this solves:
![](https://cloud.githubusercontent.com/assets/550412/6984297/aad44558-da27-11e4-91e4-c992c80a9dd5.png)

There's some space between the "approve" and "edit" buttons of the sources but not of their "edit" and "reject" buttons and not between the buttons on for properties. With the patches it looks like this (on a different item):
![spans](https://cloud.githubusercontent.com/assets/78236/6985772/249cd72e-da37-11e4-813f-aafbb5af9fbf.png)

