### PR TITLE
Adds support of negative coordinates to backend parser

### DIFF
--- a/backend/Parser.cc
+++ b/backend/Parser.cc
@@ -23,7 +23,7 @@ PropertyValue parsePropertyValue(std::string property, std::string value) {
     static boost::regex re_num("\\s*(\\+|-)\\d+(\\.\\d+)?\\s*");
 
     // locations (@LAT/LONG)
-    static boost::regex re_loc("\\s*@(\\d{1,2}(?:\\.\\d+)?)/(\\d{1,3}(?:\\.\\d+))?\\s*");
+    static boost::regex re_loc("\\s*@([+-]?\\d{1,2}(?:\\.\\d+)?)/([+-]?\\d{1,3}(?:\\.\\d+))?\\s*");
 
     // text (en:"He's a jolly good fellow")
     static boost::regex re_text("\\s*(?:(\\w{2}):)?\"([^\"\\\\]*(\\\\.[^\"\\\\]*)*)\"\\s*");

--- a/backend/test/ParserTest.cc
+++ b/backend/test/ParserTest.cc
@@ -48,12 +48,12 @@ TEST(ParserTest, ParseLangString) {
 }
 
 TEST(ParserTest, ParseLocation) {
-    std::vector<Statement> result = parseString("Q123\tP123\t@47.11/10.09\n");
+    std::vector<Statement> result = parseString("Q123\tP123\t@47.11/-10.09\n");
 
     ASSERT_EQ(result.size(), 1);
     ASSERT_EQ(result[0].getQID(), "Q123");
     ASSERT_EQ(result[0].getProperty(), "P123");
-    ASSERT_EQ(result[0].getValue(), Value(47.11,10.09));
+    ASSERT_EQ(result[0].getValue(), Value(47.11,-10.09));
 }
 
 TEST(ParserTest, ParseTime) {


### PR DESCRIPTION
It was not possible to feed Primary Source with negative geocoodinates