### PR TITLE
Uses the new Wikibase serialization format for time

### DIFF
--- a/backend/model/Statement.cc
+++ b/backend/model/Statement.cc
@@ -215,7 +215,7 @@ bool operator==(const Statement &lhs, const Statement &rhs) {
 std::string toWikidataString(const Time& t) {
     std::ostringstream out;
     out << std::setfill('0')
-        << "+" << std::setw(11) << (int) t.year()
+        << "+" << std::setw(4) << (int) t.year()
         << "-" << std::setw(2) << (int) t.month()
         << "-" << std::setw(2) << (int) t.day()
         << "T" << std::setw(2) << (int) t.hour()

--- a/backend/test/SerializerTest.cc
+++ b/backend/test/SerializerTest.cc
@@ -36,7 +36,7 @@ TEST(SerializerTest, TSV) {
     Statement s4 = NewStatement("Q123", NewPropertyValue("P123", NewTime(1967, 0, 0, 0, 0, 0, 9)));
     std::stringstream out4;
     writeStatementTSV(s4, &out4);
-    ASSERT_EQ(out4.str(), "Q123\tP123\t+00000001967-00-00T00:00:00Z/9\n");
+    ASSERT_EQ(out4.str(), "Q123\tP123\t+1967-00-00T00:00:00Z/9\n");
 
     Statement s5 = NewStatement("Q123", NewPropertyValue("P123", NewValue(47.11, -10.09)));
     std::stringstream out5;

--- a/backend/test/StatementTest.cc
+++ b/backend/test/StatementTest.cc
@@ -57,10 +57,10 @@ TEST(ValueTest, Equality) {
 
 TEST(TimeTest, toWikidataString) {
     Value t1 = NewTime(1917, 01, 01, 0, 0, 0, 11);
-    Value t2 = NewTime(1917, 0, 0, 0, 0, 0, 9);
+    Value t2 = NewTime(19170, 0, 0, 0, 0, 0, 9);
 
-    ASSERT_EQ(toWikidataString(t1.time()), "+00000001917-01-01T00:00:00Z/11");
-    ASSERT_EQ(toWikidataString(t2.time()), "+00000001917-00-00T00:00:00Z/9");
+    ASSERT_EQ(toWikidataString(t1.time()), "+1917-01-01T00:00:00Z/11");
+    ASSERT_EQ(toWikidataString(t2.time()), "+19170-00-00T00:00:00Z/9");
 }
 
 TEST(TimeTest, toSQLString) {


### PR DESCRIPTION
Introduces a difference from the TSV specification but makes times easier to manipulate (they have the same representation as in Wikibase)

Closes #90 